### PR TITLE
Fix calls to missing functions

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -27,14 +27,6 @@ func NewClient(url, user, password string, transport http.RoundTripper) (*Rpc, e
 	return newClient(url, user, password, client)
 }
 
-func NewClientHttpClient(url, user, password string, httpClient *http.Client) (*Rpc, error) {
-	client, err := xmlrpc.NewClientHttpClient(url, httpClient)
-	if err != nil {
-		return nil, err
-	}
-	return newClient(url, user, password, client)
-}
-
 func newClient(url, user, password string, client *xmlrpc.Client) (*Rpc, error) {
 	return &Rpc{
 		Client:     client,

--- a/main.go
+++ b/main.go
@@ -51,13 +51,6 @@ func main() {
 		defer pprof.StopCPUProfile()
 	}
 
-	//client := &http.Client{
-	//	Transport: &http.Transport{
-	//		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-	//	},
-	//}
-	//apiClient, err := api.NewClientHttpClient(url, user, password, client)
-
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	}


### PR DESCRIPTION
original xmlrpc lib (github.com/kolo/xmlrpc) is used, so xml.NewClientHttpClient is no longer avaiable