### PR TITLE
Fix ident in XML representation of VMTemplate

### DIFF
--- a/ocatypes/ocatypes.go
+++ b/ocatypes/ocatypes.go
@@ -274,7 +274,7 @@ type HostTemplate struct {
 
 // VMTemplate represents a VM template.
 type VMTemplate struct {
-	ID       int          `xml:"TEMPLATE_ID"`
+	ID       int          `xml:"ID"`
 	Name     string       `xml:"NAME"`
 	Uname    string       `xml:"UNAME"`
 	RegTime  int          `xml:"REGTIME"`


### PR DESCRIPTION
Hi, 
I'm using Your great OpenNebula RPC implementation, but I've found an error in the XML representation of the VMTemplate. An iteration of all templates shows that the ident of the VMTemplate is allways '0'. I changed the ident to 'ID'. Now it works fine.
Cheers Ulli.